### PR TITLE
Rename ``define`` function to ``defineLanguageRule`` to avoid RequireJS issues

### DIFF
--- a/plurals.js
+++ b/plurals.js
@@ -23,13 +23,13 @@
     return false;
   }
 
-  function define(languages, rule) {
+  function defineLanguageRule(languages, rule) {
     for ( var i = 0; i < languages.length; ++i ) {
       Data[ languages[i] ] = rule;
     }
   }
 
-  define([
+  defineLanguageRule([
     'az', 'bm', 'my', 'zh', 'dz', 'ka', 'hu', 'ig', 'id', 'ja', 'jv', 'kea',
     'kn', 'km', 'ko', 'ses', 'lo', 'kde', 'ms', 'fa', 'root', 'sah', 'sg',
     'ii', 'th', 'bo', 'to', 'tr', 'vi', 'wo', 'yo'
@@ -37,32 +37,32 @@
     return Other;
   });
 
-  define([ 'gv' ], function(n) {
+  defineLanguageRule([ 'gv' ], function(n) {
     if ( isAmong(n % 10, [ 1, 2 ]) || n % 20 === 0 ) { return One; }
     return Other;
   });
 
-  define([ 'tzm' ], function(n) {
+  defineLanguageRule([ 'tzm' ], function(n) {
     if ( n === 0 || n === 1 ) { return One; }
     if ( isInt(n) && n >= 11 && n <= 99 ) { return One; }
     return Other;
   });
 
-  define([ 'mk' ], function(n) {
+  defineLanguageRule([ 'mk' ], function(n) {
     return n % 10 === 1 && n !== 11 ? One : Other;
   });
 
-  define([ 'fr', 'ff', 'kab' ], function(n) {
+  defineLanguageRule([ 'fr', 'ff', 'kab' ], function(n) {
     return n >= 0 && n < 2 ? One : Other;
   });
 
-  define([
+  defineLanguageRule([
     'ak', 'am', 'bh', 'fil', 'guw', 'hi', 'ln', 'mg', 'nso', 'tl', 'ti', 'wa'
   ], function(n) {
     return n === 0 || n === 1 ? One : Other;
   });
 
-  define([
+  defineLanguageRule([
     'af', 'sq', 'eu', 'bem', 'bn', 'brx', 'bg', 'ca', 'chr', 'cgg', 'da', 'dv',
     'nl', 'en', 'eo', 'et', 'ee', 'fo', 'fi', 'fur', 'gl', 'lg', 'de', 'el',
     'gu', 'ha', 'haw', 'he', 'is', 'it', 'kl', 'kk', 'ku', 'lb', 'ml', 'mr',
@@ -73,25 +73,25 @@
     return n === 1 ? One : Other;
   });
 
-  define([ 'lv' ], function(n) {
+  defineLanguageRule([ 'lv' ], function(n) {
     if (n === 0) { return Zero; }
     if (n % 10 === 1 && n % 100 !== 11) { return One; }
     return Other;
   });
 
-  define([ 'ksh' ], function(n) {
+  defineLanguageRule([ 'ksh' ], function(n) {
     if (n === 0) { return Zero; }
     if (n === 1) { return One; }
     return Other;
   });
 
-  define([ 'lag' ], function(n) {
+  defineLanguageRule([ 'lag' ], function(n) {
     if (n === 0) { return Zero; }
     if (n > 0 && n < 2) { return One; }
     return Other;
   });
 
-  define([
+  defineLanguageRule([
     'kw', 'smn', 'iu', 'ga', 'smj', 'se', 'smi', 'sms', 'sma'
   ], function(n) {
     if (n === 1) { return One; }
@@ -99,7 +99,7 @@
     return Other;
   });
 
-  define([
+  defineLanguageRule([
     'be', 'bs', 'hr', 'ru', 'sr', 'sh', 'uk'
   ], function(n) {
     var mod10  = n % 10,
@@ -116,7 +116,7 @@
     return Other;
   });
 
-  define([ 'pl' ], function(n) {
+  defineLanguageRule([ 'pl' ], function(n) {
     var mod10  = n % 10,
         mod100 = n % 100;
 
@@ -131,7 +131,7 @@
     return Other;
   });
 
-  define([ 'lt' ], function(n) {
+  defineLanguageRule([ 'lt' ], function(n) {
     var mod10  = n % 10,
         mod100 = n % 100;
 
@@ -144,13 +144,13 @@
     return Other;
   });
 
-  define([ 'shi' ], function(n) {
+  defineLanguageRule([ 'shi' ], function(n) {
     if ( n >= 0 && n <= 1 ) { return One; }
     if ( isInt(n) && n >= 2 && n <= 9 ) { return Few; }
     return Other;
   });
 
-  define([ 'mo', 'ro' ], function(n) {
+  defineLanguageRule([ 'mo', 'ro' ], function(n) {
     var mod100 = n % 100;
 
     if ( n === 1 ) { return One; }
@@ -161,13 +161,13 @@
     return Other;
   });
 
-  define([ 'cs', 'sk' ], function(n) {
+  defineLanguageRule([ 'cs', 'sk' ], function(n) {
     if ( n === 1 ) { return One; }
     if ( isAmong(n, [ 2, 3, 4 ]) ) { return Few; }
     return Other;
   });
 
-  define([ 'sl' ], function(n) {
+  defineLanguageRule([ 'sl' ], function(n) {
     var mod100 = n % 100;
     if ( mod100 === 1 ) { return One; }
     if ( mod100 === 2 ) { return Two; }
@@ -175,7 +175,7 @@
     return Other;
   });
 
-  define([ 'mt' ], function(n) {
+  defineLanguageRule([ 'mt' ], function(n) {
     if ( n === 1 ) { return One; }
     var mod100 = n % 100;
     if ( isInt(mod100) && mod100 >= 2 && mod100 <= 10 ) { return Few; }
@@ -183,7 +183,7 @@
     return Other;
   });
 
-  define([ 'ar' ], function(n) {
+  defineLanguageRule([ 'ar' ], function(n) {
     if ( n === 0 ) { return Zero; }
     if ( n === 1 ) { return One; }
     if ( n === 2 ) { return Two; }
@@ -193,7 +193,7 @@
     return Other;
   });
 
-  define([ 'br', 'cy' ], function(n) {
+  defineLanguageRule([ 'br', 'cy' ], function(n) {
     switch ( n ) {
       case 0: return Zero;
       case 1: return One;


### PR DESCRIPTION
`define` causes issues when trying to use with RequireJS which means it can't be loaded as an AMD module using the shim config. It also breaks when trying to optimize using r.js & uglify/uglify2.

`defineLanguageRule` is a more descriptive name also.
